### PR TITLE
Removes bridgedb url from p2 sites ui in bioclipse

### DIFF
--- a/features/net.bioclipse.bridgedb_site/feature.xml
+++ b/features/net.bioclipse.bridgedb_site/feature.xml
@@ -20,10 +20,6 @@ et al.
 The BridgeDB library code has the Apache 2.0 License.
    </license>
 
-   <url>
-      <discovery label="BridgeDB website" url="http://www.bridgedb.org/"/>
-   </url>
-
    <includes
          id="net.bioclipse.bridgedb_feature"
          version="0.0.0"/>


### PR DESCRIPTION
When installing from http://devel.bioclipse.net 
http://www.bridgedb.org is added as an available update site
This commit removes <url> <discovery ... /></url> and fixes this problem.
